### PR TITLE
[macOS Sierra] fix a build failure on macOS Sierra and higher.

### DIFF
--- a/Fugu15/Makefile
+++ b/Fugu15/Makefile
@@ -4,6 +4,7 @@ all: Fugu15.tipa
 
 Fugu15.tipa: build/Build/Products/Debug-iphoneos/Fugu15.app
 	@echo Ad-Hoc signing Fugu15
+	xattr -rc build/Build/Products/Debug-iphoneos/Fugu15.app
 	codesign -s - --entitlements Fugu15/Fugu15.entitlements build/Build/Products/Debug-iphoneos/Fugu15.app
 	@echo Fake-signing Fugu15
 	../Tools/fastPathSign/fastPathSign build/Build/Products/Debug-iphoneos/Fugu15.app


### PR DESCRIPTION
Code signing no longer allows any file in an app bundle to have an extended attribute containing a resource fork or Finder info, since macOS Sierra. Hence remove them just before `codesign`.